### PR TITLE
Parse training data correctly

### DIFF
--- a/neuralNet/trainNet.js
+++ b/neuralNet/trainNet.js
@@ -14,7 +14,7 @@ const fs = require('fs')
 const preparedTrainingData = trainingData.map(set => {
     return {
         input: set.slice(0, 9),
-        output: set.slice(9)
+        output: set.slice(9, 18),
     }
 })
 


### PR DESCRIPTION
`multiLabelTrainingData` is of the form`[...currentBoardState, ...nextBoardState]` so it should be parsed into `preparedTrainingData` as such.

Currently it only uses the first square of the `nextBoardState`.

This was tested on the `aivs` site and it works really well. Much better than the other AIs. Not surprising because it now has the correct training data 😀